### PR TITLE
Fix pattern for humidity channels. Percent sign must be escaped.

### DIFF
--- a/addons/binding/org.openhab.binding.ambientweather1400ip/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.ambientweather1400ip/ESH-INF/thing/thing-types.xml
@@ -63,14 +63,14 @@
         <label>Indoor Humidity</label>
         <description>Current Humidity Indoor</description>
         <category>Thermostat</category>
-        <state pattern="%.1f %" readOnly="true"/>
+        <state pattern="%.1f %%" readOnly="true"/>
     </channel-type>
     <channel-type id="humidity_chan_outdoor">
         <item-type>Number</item-type>
         <label>Outdoor Humidity</label>
         <description>Current Humidity Outdoor</description>
         <category>Thermostat</category>
-        <state pattern="%.1f %" readOnly="true"/>
+        <state pattern="%.1f %%" readOnly="true"/>
     </channel-type>
     <channel-type id="pressure_chan_abs">
         <item-type>Number</item-type>


### PR DESCRIPTION
Not escaped percend sign in a channel pattern is causing a javascript error

```
angular.min.js:117 SyntaxError: [sprintf] unexpected placeholder
    at Function.b.parse (sprintf.min.js:3)
    at b (sprintf.min.js:3)
    at Object.getItemStateText (utility.js:1)
    at controllers.min.js:1
    at m.$eval (angular.min.js:145)
    at m.$apply (angular.min.js:145)
    at i (controllers.min.js:1)
    at controllers.min.js:1
    at Array.forEach (<anonymous>)
    at controllers.min.js:1
```