### PR TITLE
[Envoy] Compile requirements and Username configurable

### DIFF
--- a/addons/binding/org.openhab.binding.enphaseenvoy/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.enphaseenvoy/ESH-INF/thing/thing-types.xml
@@ -24,6 +24,10 @@
 				<label>Serial Number</label>
 				<description>Enphase Envoy Serial Number</description>
 			</parameter>
+            <parameter name="username" type="text" required="true">
+                <label>Username</label>
+                <description>Enphase Envoy Username</description>
+            </parameter>			
 			<parameter name="password" type="text" required="true">
 				<label>Password</label>
 				<description>Enphase Envoy Password</description>

--- a/addons/binding/org.openhab.binding.enphaseenvoy/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.enphaseenvoy/META-INF/MANIFEST.MF
@@ -10,7 +10,7 @@ Bundle-Name: EnphaseEnvoy Binding
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.openhab.binding.enphaseenvoy;singleton:=true
 Bundle-Vendor: openHAB
-Bundle-Version: 2.3.0.qualifier
+Bundle-Version: 2.5.0.qualifier
 Import-Package: 
  com.google.gson,
  com.google.gson.annotations,
@@ -27,6 +27,6 @@ Import-Package:
  org.eclipse.smarthome.core.thing.type,
  org.eclipse.smarthome.core.types,
  org.eclipse.smarthome.core.util,
+ org.osgi.framework,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
-Require-Bundle: org.eclipse.osgi

--- a/addons/binding/org.openhab.binding.enphaseenvoy/build.properties
+++ b/addons/binding/org.openhab.binding.enphaseenvoy/build.properties
@@ -7,4 +7,5 @@ bin.includes=META-INF/,\
              lib/okhttp-digest-1.17.jar,\
              OSGI-INF/,\
              ESH-INF/,\
-             NOTICE
+             NOTICE,\
+			 about.html

--- a/addons/binding/org.openhab.binding.enphaseenvoy/pom.xml
+++ b/addons/binding/org.openhab.binding.enphaseenvoy/pom.xml
@@ -7,12 +7,12 @@
 	<parent>
 		<artifactId>pom</artifactId>
 		<groupId>org.openhab.binding</groupId>
-		<version>2.3.0-SNAPSHOT</version>
+		<version>2.5.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>net.hentschel.openhab</groupId>
 	<artifactId>org.openhab.binding.enphaseenvoy</artifactId>
 	<packaging>eclipse-plugin</packaging>
 	<name>EnphaseEnvoy Binding</name>
-	<version>0.0.1</version>
+	
 </project>

--- a/addons/binding/org.openhab.binding.enphaseenvoy/src/main/java/org/openhab/binding/enphaseenvoy/discovery/internal/EnphaseEnvoyDiscoveryParticipant.java
+++ b/addons/binding/org.openhab.binding.enphaseenvoy/src/main/java/org/openhab/binding/enphaseenvoy/discovery/internal/EnphaseEnvoyDiscoveryParticipant.java
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.enphaseenvoy.discovery.internal;
+
+import java.net.Inet4Address;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import javax.jmdns.ServiceInfo;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.config.discovery.DiscoveryResult;
+import org.eclipse.smarthome.config.discovery.DiscoveryResultBuilder;
+import org.eclipse.smarthome.config.discovery.DiscoveryServiceCallback;
+import org.eclipse.smarthome.config.discovery.ExtendedDiscoveryService;
+import org.eclipse.smarthome.config.discovery.mdns.MDNSDiscoveryParticipant;
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.eclipse.smarthome.core.thing.ThingUID;
+import org.openhab.binding.enphaseenvoy.internal.EnphaseEnvoyBindingConstants;
+import org.openhab.binding.enphaseenvoy.internal.EnphaseEnvoyBridgeHandler;
+import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author thomashentschel
+ *
+ */
+@Component(service = MDNSDiscoveryParticipant.class, immediate = true)
+public class EnphaseEnvoyDiscoveryParticipant implements MDNSDiscoveryParticipant, ExtendedDiscoveryService {
+    private final Logger logger = LoggerFactory.getLogger(EnphaseEnvoyDiscoveryParticipant.class);
+    @SuppressWarnings("unused")
+    private DiscoveryServiceCallback serviceCallback;
+
+    /**
+     *
+     */
+    public EnphaseEnvoyDiscoveryParticipant() {
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.eclipse.smarthome.config.discovery.mdns.MDNSDiscoveryParticipant#getSupportedThingTypeUIDs()
+     */
+    @Override
+    public @NonNull Set<@NonNull ThingTypeUID> getSupportedThingTypeUIDs() {
+        Set<ThingTypeUID> result = new HashSet<ThingTypeUID>();
+        result.add(EnphaseEnvoyBindingConstants.THING_TYPE_ENVOY_BRIDGE);
+        return result;
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.eclipse.smarthome.config.discovery.mdns.MDNSDiscoveryParticipant#getServiceType()
+     */
+    @Override
+    public @NonNull String getServiceType() {
+        return "_enphase-envoy._tcp.local.";
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.eclipse.smarthome.config.discovery.mdns.MDNSDiscoveryParticipant#createResult(javax.jmdns.ServiceInfo)
+     */
+    @Override
+    public @Nullable DiscoveryResult createResult(@NonNull ServiceInfo info) {
+        String id = info.getName();
+        logger.debug("id found: " + id + " with type: " + info.getType());
+        if (!id.contains("envoy")) {
+            return null;
+        }
+        logger.debug("envoy id found: " + id + " with type: " + info.getType());
+
+        if (info.getInet4Addresses().length == 0 || info.getInet4Addresses()[0] == null) {
+            return null;
+        }
+
+        ThingUID uid = this.getThingUID(info);
+        if (uid == null) {
+            return null;
+        }
+
+        Inet4Address hostname = info.getInet4Addresses()[0];
+
+        String serial = info.getPropertyString(EnphaseEnvoyBindingConstants.DISCOVERY_SERIAL);
+        String version = info.getPropertyString(EnphaseEnvoyBindingConstants.DISCOVERY_VERSION);
+        String password = EnphaseEnvoyBridgeHandler.getPasswordFromSerial(serial);
+        Map<String, Object> properties = new HashMap<>(0);
+        properties.put(EnphaseEnvoyBindingConstants.CONFIG_HOSTNAME_ID,
+                hostname != null ? hostname.getHostAddress() : "");
+        properties.put(EnphaseEnvoyBindingConstants.CONFIG_SERIAL_ID, serial);
+        properties.put(EnphaseEnvoyBindingConstants.CONFIG_PASSWORD_ID, password);
+        properties.put(EnphaseEnvoyBindingConstants.VERSION, version);
+        DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(uid).withProperties(properties)
+                .withRepresentationProperty(serial).withLabel("Enphase Envoy " + serial).build();
+        return discoveryResult;
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.eclipse.smarthome.config.discovery.mdns.MDNSDiscoveryParticipant#getThingUID(javax.jmdns.ServiceInfo)
+     */
+    @Override
+    public @Nullable ThingUID getThingUID(@NonNull ServiceInfo info) {
+        String id = info.getName();
+        if (!id.contains("envoy")) {
+            return null;
+        }
+        if (info.getInet4Addresses().length == 0 || info.getInet4Addresses()[0] == null) {
+            return null;
+        }
+        logger.debug("ServiceInfo addr: {}", info.getInet4Addresses()[0]);
+        if (info.getType() != null) {
+            if (info.getType().equals(getServiceType())) {
+                String serial = info.getPropertyString(EnphaseEnvoyBindingConstants.DISCOVERY_SERIAL);
+                logger.info("Discovered a Envoy with id '{}'", serial);
+                return new ThingUID(EnphaseEnvoyBindingConstants.THING_TYPE_ENVOY_BRIDGE, serial);
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public void setDiscoveryServiceCallback(@NonNull DiscoveryServiceCallback callback) {
+        this.serviceCallback = callback;
+    }
+}

--- a/addons/binding/org.openhab.binding.enphaseenvoy/src/main/java/org/openhab/binding/enphaseenvoy/discovery/internal/EnphaseEnvoyDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.enphaseenvoy/src/main/java/org/openhab/binding/enphaseenvoy/discovery/internal/EnphaseEnvoyDiscoveryService.java
@@ -1,0 +1,150 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.enphaseenvoy.discovery.internal;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.smarthome.config.discovery.AbstractDiscoveryService;
+import org.eclipse.smarthome.config.discovery.DiscoveryResult;
+import org.eclipse.smarthome.config.discovery.DiscoveryResultBuilder;
+import org.eclipse.smarthome.config.discovery.DiscoveryServiceCallback;
+import org.eclipse.smarthome.config.discovery.ExtendedDiscoveryService;
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.eclipse.smarthome.core.thing.ThingUID;
+import org.openhab.binding.enphaseenvoy.internal.EnphaseEnvoyBindingConstants;
+import org.openhab.binding.enphaseenvoy.internal.EnphaseEnvoyBridgeConfiguration;
+import org.openhab.binding.enphaseenvoy.internal.EnphaseEnvoyBridgeHandler;
+import org.openhab.binding.enphaseenvoy.protocol.internal.InverterProduction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author thomashentschel
+ *
+ */
+public class EnphaseEnvoyDiscoveryService extends AbstractDiscoveryService implements ExtendedDiscoveryService {
+
+    private static final Logger logger = LoggerFactory.getLogger(EnphaseEnvoyDiscoveryService.class);
+    private static final int TIMEOUT = 20;
+    private static final int REFRESH = 15;
+    private EnphaseEnvoyBridgeHandler bridgeHandler;
+    private Runnable discoveryRunnable;
+    private ScheduledFuture<?> discoveryJob;
+    private DiscoveryServiceCallback discoveryServiceCallback;
+    private boolean scanInProgress = false;
+    private int scancount = 0;
+
+    public EnphaseEnvoyDiscoveryService(EnphaseEnvoyBridgeHandler bridgeHandler) {
+        super(Collections.singleton(EnphaseEnvoyBindingConstants.THING_TYPE_ENVOY_INVERTER), TIMEOUT, true);
+        this.bridgeHandler = bridgeHandler;
+        this.discoveryRunnable = new Runnable() {
+
+            @Override
+            public void run() {
+                EnphaseEnvoyDiscoveryService.this.startScan();
+            }
+        };
+    }
+
+    public void activate() {
+        bridgeHandler.registerDiscoveryService(this);
+        super.activate(null);
+    }
+
+    @Override
+    public void deactivate() {
+        super.deactivate();
+        bridgeHandler.unregisterDiscoveryService();
+    }
+
+    @Override
+    public void setDiscoveryServiceCallback(@NonNull DiscoveryServiceCallback discoveryServiceCallback) {
+        this.discoveryServiceCallback = discoveryServiceCallback;
+    }
+
+    @Override
+    protected void startBackgroundDiscovery() {
+        logger.debug("Start enphase device background discovery");
+        if (this.discoveryJob == null || this.discoveryJob.isCancelled()) {
+            this.discoveryJob = scheduler.scheduleWithFixedDelay(this.discoveryRunnable, 0, REFRESH, TimeUnit.SECONDS);
+        }
+    }
+
+    @Override
+    protected void stopBackgroundDiscovery() {
+        logger.debug("Stop enphase device background discovery");
+        if (this.discoveryJob != null && !this.discoveryJob.isCancelled()) {
+            this.discoveryJob.cancel(true);
+            this.discoveryJob = null;
+        }
+    }
+
+    @Override
+    protected void startScan() {
+        if (this.scanInProgress) {
+            return;
+        }
+        this.scanInProgress = true;
+        try {
+            if (this.bridgeHandler.getConfiguration().isComplete()) {
+                logger.trace("Scanning for inverters");
+                this.scanForInverterThings();
+            } else {
+                logger.debug("connection to Enphase failed, leaving device scan");
+                return;
+            }
+        } finally {
+            this.scanInProgress = false;
+        }
+    }
+
+    private void scanForInverterThings() {
+        EnphaseEnvoyBridgeConfiguration config = this.bridgeHandler.getConfiguration();
+        if (!config.isComplete()) {
+            return;
+        }
+        List<InverterProduction> inverters = null;
+        try {
+            inverters = this.bridgeHandler.getInverterParser().getInverterData(config);
+        } catch (IOException e) {
+            logger.warn("envoy scan for inverters failed due to: {}", e.getMessage());
+            return;
+        }
+        if (inverters == null) {
+            return;
+        }
+        ThingUID bridgeID = this.bridgeHandler.getThing().getUID();
+        for (InverterProduction inverter : inverters) {
+            ThingTypeUID theThingTypeUid = EnphaseEnvoyBindingConstants.THING_TYPE_ENVOY_INVERTER;
+            String thingID = inverter.serialNumber;
+            ThingUID thingUID = new ThingUID(theThingTypeUid, thingID);
+            if (this.discoveryServiceCallback.getExistingDiscoveryResult(thingUID) != null) {
+                logger.trace("Thing " + thingUID.toString() + " was already discovered");
+                return;
+            }
+            if (this.discoveryServiceCallback.getExistingThing(thingUID) != null) {
+                logger.trace("Thing " + thingUID.toString() + " already exists");
+                return;
+            }
+
+            this.scancount++;
+            logger.trace("Bridge {} for device {} is in state {}, scan count {}", bridgeID, thingUID,
+                    this.bridgeHandler.getThing().getStatus(), this.scancount);
+            DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(thingUID).withBridge(bridgeID)
+                    .withRepresentationProperty(inverter.serialNumber).withBridge(bridgeID)
+                    .withLabel("Enphase Inverter " + inverter.serialNumber).build();
+            thingDiscovered(discoveryResult);
+        }
+    }
+}

--- a/addons/binding/org.openhab.binding.enphaseenvoy/src/main/java/org/openhab/binding/enphaseenvoy/internal/EnphaseEnvoyBindingConstants.java
+++ b/addons/binding/org.openhab.binding.enphaseenvoy/src/main/java/org/openhab/binding/enphaseenvoy/internal/EnphaseEnvoyBindingConstants.java
@@ -1,14 +1,10 @@
 /**
- * Copyright (c) 2014,2018 by the respective copyright holders.
+ * Copyright (c) 2010-2018 by the respective copyright holders.
  *
- * See the NOTICE file(s) distributed with this work for additional
- * information regarding copyright ownership.
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0
- *
- * SPDX-License-Identifier: EPL-2.0
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
  */
 package org.openhab.binding.enphaseenvoy.internal;
 
@@ -44,6 +40,7 @@ public class EnphaseEnvoyBindingConstants {
 
     public static final String CONFIG_HOSTNAME_ID = "hostname";
     public static final String CONFIG_SERIAL_ID = "serialnumber";
+    public static final String CONFIG_USERNAME_ID = "username";
     public static final String CONFIG_PASSWORD_ID = "password";
     public static final String CONFIG_SCANPERIOD_ID = "scanperiod";
     public static final String VERSION = "version";

--- a/addons/binding/org.openhab.binding.enphaseenvoy/src/main/java/org/openhab/binding/enphaseenvoy/internal/EnphaseEnvoyBridgeConfiguration.java
+++ b/addons/binding/org.openhab.binding.enphaseenvoy/src/main/java/org/openhab/binding/enphaseenvoy/internal/EnphaseEnvoyBridgeConfiguration.java
@@ -1,14 +1,10 @@
 /**
- * Copyright (c) 2014,2018 by the respective copyright holders.
+ * Copyright (c) 2010-2018 by the respective copyright holders.
  *
- * See the NOTICE file(s) distributed with this work for additional
- * information regarding copyright ownership.
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0
- *
- * SPDX-License-Identifier: EPL-2.0
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
  */
 package org.openhab.binding.enphaseenvoy.internal;
 
@@ -24,11 +20,12 @@ public class EnphaseEnvoyBridgeConfiguration {
      */
     public String hostname;
     public String serialnumber;
+    public String username;
     public String password;
     public int scanperiod;
 
     public boolean isComplete() {
-        return hostname != null && hostname.length() > 0 && password != null && password.length() > 0
-                && serialnumber != null && serialnumber.length() > 6;
+        return hostname != null && hostname.length() > 0 && username != null && username.length() > 0
+                && password != null && password.length() > 0 && serialnumber != null && serialnumber.length() > 6;
     }
 }

--- a/addons/binding/org.openhab.binding.enphaseenvoy/src/main/java/org/openhab/binding/enphaseenvoy/internal/EnphaseEnvoyBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.enphaseenvoy/src/main/java/org/openhab/binding/enphaseenvoy/internal/EnphaseEnvoyBridgeHandler.java
@@ -1,14 +1,10 @@
 /**
- * Copyright (c) 2014,2018 by the respective copyright holders.
+ * Copyright (c) 2010-2018 by the respective copyright holders.
  *
- * See the NOTICE file(s) distributed with this work for additional
- * information regarding copyright ownership.
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0
- *
- * SPDX-License-Identifier: EPL-2.0
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
  */
 package org.openhab.binding.enphaseenvoy.internal;
 
@@ -38,9 +34,9 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.BaseBridgeHandler;
 import org.eclipse.smarthome.core.types.Command;
-import org.openhab.binding.enphaseenvoy.discovery.EnphaseEnvoyDiscoveryService;
-import org.openhab.binding.enphaseenvoy.protocol.InverterProduction;
-import org.openhab.binding.enphaseenvoy.protocol.SystemProduction;
+import org.openhab.binding.enphaseenvoy.discovery.internal.EnphaseEnvoyDiscoveryService;
+import org.openhab.binding.enphaseenvoy.protocol.internal.InverterProduction;
+import org.openhab.binding.enphaseenvoy.protocol.internal.SystemProduction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/addons/binding/org.openhab.binding.enphaseenvoy/src/main/java/org/openhab/binding/enphaseenvoy/internal/EnphaseEnvoyHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.enphaseenvoy/src/main/java/org/openhab/binding/enphaseenvoy/internal/EnphaseEnvoyHandlerFactory.java
@@ -1,14 +1,10 @@
 /**
- * Copyright (c) 2014,2018 by the respective copyright holders.
+ * Copyright (c) 2010-2018 by the respective copyright holders.
  *
- * See the NOTICE file(s) distributed with this work for additional
- * information regarding copyright ownership.
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0
- *
- * SPDX-License-Identifier: EPL-2.0
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
  */
 package org.openhab.binding.enphaseenvoy.internal;
 
@@ -29,7 +25,7 @@ import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.BaseThingHandlerFactory;
 import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
-import org.openhab.binding.enphaseenvoy.discovery.EnphaseEnvoyDiscoveryService;
+import org.openhab.binding.enphaseenvoy.discovery.internal.EnphaseEnvoyDiscoveryService;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;

--- a/addons/binding/org.openhab.binding.enphaseenvoy/src/main/java/org/openhab/binding/enphaseenvoy/internal/EnphaseEnvoyInverterHandler.java
+++ b/addons/binding/org.openhab.binding.enphaseenvoy/src/main/java/org/openhab/binding/enphaseenvoy/internal/EnphaseEnvoyInverterHandler.java
@@ -1,14 +1,10 @@
 /**
- * Copyright (c) 2014,2018 by the respective copyright holders.
+ * Copyright (c) 2010-2018 by the respective copyright holders.
  *
- * See the NOTICE file(s) distributed with this work for additional
- * information regarding copyright ownership.
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0
- *
- * SPDX-License-Identifier: EPL-2.0
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
  */
 package org.openhab.binding.enphaseenvoy.internal;
 
@@ -23,7 +19,7 @@ import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.binding.BaseThingHandler;
 import org.eclipse.smarthome.core.types.Command;
-import org.openhab.binding.enphaseenvoy.protocol.InverterProduction;
+import org.openhab.binding.enphaseenvoy.protocol.internal.InverterProduction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/addons/binding/org.openhab.binding.enphaseenvoy/src/main/java/org/openhab/binding/enphaseenvoy/internal/InverterParser.java
+++ b/addons/binding/org.openhab.binding.enphaseenvoy/src/main/java/org/openhab/binding/enphaseenvoy/internal/InverterParser.java
@@ -1,3 +1,11 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
 package org.openhab.binding.enphaseenvoy.internal;
 
 import java.io.IOException;
@@ -7,7 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.openhab.binding.enphaseenvoy.protocol.InverterProduction;
+import org.openhab.binding.enphaseenvoy.protocol.internal.InverterProduction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,6 +34,10 @@ import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
 
+/**
+ * @author thomashentschel
+ *
+ */
 public class InverterParser {
 
     private static final Logger logger = LoggerFactory.getLogger(InverterParser.class);
@@ -60,9 +72,10 @@ public class InverterParser {
     }
 
     private String getInverters(EnphaseEnvoyBridgeConfiguration config) throws IOException {
+        String username = config.username;
         String passwd = config.password;
 
-        DigestAuthenticator authenticator = new DigestAuthenticator(new Credentials("envoy", passwd));
+        DigestAuthenticator authenticator = new DigestAuthenticator(new Credentials(username, passwd));
         OkHttpClient client = new OkHttpClient.Builder()
                 .authenticator(new CachingAuthenticatorDecorator(authenticator, authCache))
                 .addInterceptor(new AuthenticationCacheInterceptor(authCache)).build();

--- a/addons/binding/org.openhab.binding.enphaseenvoy/src/main/java/org/openhab/binding/enphaseenvoy/protocol/internal/InverterProduction.java
+++ b/addons/binding/org.openhab.binding.enphaseenvoy/src/main/java/org/openhab/binding/enphaseenvoy/protocol/internal/InverterProduction.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.enphaseenvoy.protocol.internal;
+
+/**
+ * @author thomashentschel
+ *
+ */
+public class InverterProduction {
+    public String serialNumber = "";
+    public long lastReportDate = 0;
+    public int devType = 0;
+    public int lastReportWatts = 0;
+    public int maxReportWatts = 0;
+}

--- a/addons/binding/org.openhab.binding.enphaseenvoy/src/main/java/org/openhab/binding/enphaseenvoy/protocol/internal/SystemProduction.java
+++ b/addons/binding/org.openhab.binding.enphaseenvoy/src/main/java/org/openhab/binding/enphaseenvoy/protocol/internal/SystemProduction.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.enphaseenvoy.protocol.internal;
+
+/**
+ * @author thomashentschel
+ *
+ */
+public class SystemProduction {
+
+    public long wattHoursToday;
+    public long wattHoursSevenDays;
+    public long wattHoursLifetime;
+    public long wattsNow;
+}


### PR DESCRIPTION
To compile against the latest OH master branch source needed to be updated to conform to the requirements; Copyright, Author, Build properties.

Rather than a hardcoded username of 'envoy', added the ability to let the user configure the username the binding uses when authenticating against the Envoy device.

When testing the changes I did see authentication errors, if the binding uses a user/pass that fails than the user/pass is updated to the correct ones the binding still fails, with the below Warning.  

`2019-01-08 21:55:31.481 [WARN ] [.e.i.EnphaseEnvoyBridgeHandler:295  ] - envoy scanner update failed: unsupported auth scheme: [���A]`

Currently the workaround is to restart Openhab.  When the server restarts and uses the correct credentials initially no errors are seen and the data is pulled from the Inverters page.  If the correct credentials are used initially, the authentication process is successful.